### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in Zip Extraction and Downloads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,1 @@
+- 2024-05-24: [Critical] Path Traversal: When extracting zip files, always use the return value of `ZipFile.extract()` rather than concatenating the target directory with the zip entry name, as malicious zip entries with absolute paths or `..` can escape the intended extraction directory.

--- a/build.py
+++ b/build.py
@@ -18,9 +18,12 @@ def download_to(request, output_dir, filename=None):
 
     file_path = output_dir
     if filename is None:
-        file_path = file_path / res.url.split("/")[-1]
-    else:
-        file_path = file_path / filename
+        filename = res.url.split("/")[-1]
+
+    # Sanitize filename to prevent path traversal
+    filename = Path(filename).name
+    file_path = file_path / filename
+
     with open(str(file_path), 'wb') as f:
         while True:
             chunk = res.read(16*1024)
@@ -50,8 +53,8 @@ def download_zip_and_extract_to_bin(work_dir, url, zip_filename, file_filter):
         with zipfile.ZipFile(downloaded_zip, 'r') as z:
             for file_path_str in z.namelist():
                 if file_filter(file_path_str):
-                    z.extract(file_path_str, tempdir)
-                    extracted_file = tempdir / file_path_str
+                    extracted_file_str = z.extract(file_path_str, tempdir)
+                    extracted_file = Path(extracted_file_str)
                     if not extracted_file.is_dir():
                         shutil.move(extracted_file, bin_dir)
 


### PR DESCRIPTION
**Severity:** CRITICAL
**Vulnerability:** Path Traversal
**Impact:** A maliciously crafted Zip file or server redirect could allow writing files outside the intended installation directory (e.g., overwriting system files), potentially leading to arbitrary code execution or system compromise.
**Fix:** 
- In `download_zip_and_extract_to_bin`, rely on the return value of `ZipFile.extract()`, which intrinsically sanitizes paths and returns the safe extraction path. Previously, `tempdir / file_path_str` was used. Due to Python's `pathlib` behavior, if `file_path_str` starts with an absolute path separator, the `tempdir` is ignored and it evaluates to the absolute path directly.
- In `download_to`, use `Path(filename).name` to strip out all path traversal elements (e.g. `..`, `/`) and safely extract only the file's basename.
**Verification:** Ran Python syntax verification successfully. Code follows defensive extraction best-practices.

### Assumptions
- Python's `zipfile` built-in protection is sufficient when correctly using its return values, avoiding manual string concatenation against `tempdir`.
- Base filename behavior for `download_to` matches the expected behavior for existing valid links.

### Alternatives Not Chosen
- Manually parsing strings to remove `..`, `/`, `\`. Using `Path(filename).name` and `z.extract()` are both much more resilient against platform-specific edge cases.
- Validating the path with `is_relative_to(tempdir)`. While safe, this breaks execution instead of sanitizing it. Sanitization provides a more fault-tolerant approach here.

### How To Pivot
If `Path(filename).name` breaks a legitimate URL that we actually want to retain path structures from (none currently do), we could limit the sanitization to only when `filename` is parsed automatically from URLs, and trust explicit arguments. Change the `Path(filename).name` sanitization inside the `if filename is None:` block.

### Next Knobs
- `build.py`: `download_to` filename sanitization.
- `build.py`: `download_zip_and_extract_to_bin` extraction logic.
- `.jules/sentinel.md`: Path traversal logging entry.

---
*PR created automatically by Jules for task [2709700461528666212](https://jules.google.com/task/2709700461528666212) started by @lucasew*