### PR TITLE
🧹 Janitor: Fix formatting and unused imports in build.py

### DIFF
--- a/.jules/janitor.md
+++ b/.jules/janitor.md
@@ -1,0 +1,1 @@
+- 2026-03-01: Removed unused imports to improve code quality.

--- a/build.py
+++ b/build.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3
 
-from pathlib import Path
-from argparse import ArgumentParser
+import json
 import re
-from urllib.request import urlopen, Request, urlretrieve
 import shutil
 import tempfile
 import zipfile
-import json
+from argparse import ArgumentParser
+from pathlib import Path
+from urllib.request import urlopen
 
 parser = ArgumentParser()
 parser.add_argument("output_dir", type=Path)
+
 
 def download_to(request, output_dir, filename=None):
     res = urlopen(request)
@@ -21,9 +22,9 @@ def download_to(request, output_dir, filename=None):
         file_path = file_path / res.url.split("/")[-1]
     else:
         file_path = file_path / filename
-    with open(str(file_path), 'wb') as f:
+    with open(str(file_path), "wb") as f:
         while True:
-            chunk = res.read(16*1024)
+            chunk = res.read(16 * 1024)
             if not chunk:
                 break
             f.write(chunk)
@@ -33,13 +34,13 @@ def download_to(request, output_dir, filename=None):
 def webcat(request):
     res = urlopen(request)
     print(f"Fetching {res.url}...")
-    data = b''
+    data = b""
     while True:
         chunk = res.read(4096)
         if not chunk:
             break
         data += chunk
-    return data.decode('utf-8')
+    return data.decode("utf-8")
 
 
 def download_zip_and_extract_to_bin(work_dir, url, zip_filename, file_filter):
@@ -47,7 +48,7 @@ def download_zip_and_extract_to_bin(work_dir, url, zip_filename, file_filter):
     with tempfile.TemporaryDirectory() as tempdir:
         tempdir = Path(tempdir)
         downloaded_zip = download_to(url, tempdir, filename=zip_filename)
-        with zipfile.ZipFile(downloaded_zip, 'r') as z:
+        with zipfile.ZipFile(downloaded_zip, "r") as z:
             for file_path_str in z.namelist():
                 if file_filter(file_path_str):
                     z.extract(file_path_str, tempdir)
@@ -59,15 +60,21 @@ def download_zip_and_extract_to_bin(work_dir, url, zip_filename, file_filter):
 def is_rclone_exe(filename):
     return filename.endswith("rclone.exe")
 
+
 def is_ffmpeg_bin(filename):
     return "/bin/" in filename
+
 
 def is_executable(filename):
     return filename.endswith(".exe")
 
+
 args = parser.parse_args()
 
-for d in [args.output_dir / "root" / "Program Files", args.output_dir / "root" / "bin"]:
+for d in [
+    args.output_dir / "root" / "Program Files",
+    args.output_dir / "root" / "bin",
+]:
     d.mkdir(parents=True, exist_ok=True)
 
 # copy skeleton to output
@@ -82,8 +89,11 @@ shutil.copytree(skeleton_dir, work_dir)
 vlc_page_content = webcat("https://www.videolan.org/vlc/releases/")
 regex = r"vlc\/releases/(.*)\.html"
 last_version = next(re.finditer(regex, vlc_page_content)).groups()[0]
-final_url = f"https://get.videolan.org/vlc/{last_version}/win64/vlc-{last_version}-win64.exe"
-download_to(final_url, work_dir)
+vlc_url = (
+    f"https://get.videolan.org/vlc/{last_version}/"
+    f"win64/vlc-{last_version}-win64.exe"
+)
+download_to(vlc_url, work_dir)
 
 # 7zip
 sevenzip_page_content = webcat("https://www.7-zip.org/")
@@ -93,35 +103,80 @@ final_url = "https://www.7-zip.org/" + url_part
 download_to(final_url, work_dir, filename="7z.exe")
 
 # adwcleaner
-download_to("https://adwcleaner.malwarebytes.com/adwcleaner?channel=release", work_dir, filename="adwcleaner.exe")
+adw_url = "https://adwcleaner.malwarebytes.com/adwcleaner?channel=release"
+download_to(
+    adw_url,
+    work_dir,
+    filename="adwcleaner.exe",
+)
 
 # rclone
-download_zip_and_extract_to_bin(work_dir, "https://downloads.rclone.org/rclone-current-windows-amd64.zip", "rclone.zip", is_rclone_exe)
+download_zip_and_extract_to_bin(
+    work_dir,
+    "https://downloads.rclone.org/rclone-current-windows-amd64.zip",
+    "rclone.zip",
+    is_rclone_exe,
+)
 
 # yt-dlp
-github_release = json.loads(webcat("https://api.github.com/repos/yt-dlp/yt-dlp/releases"))[0] # primeira
-for asset in github_release['assets']:
-    if asset['name'] != "yt-dlp.exe":
+github_release = json.loads(
+    webcat("https://api.github.com/repos/yt-dlp/yt-dlp/releases")
+)[
+    0
+]  # primeira
+for asset in github_release["assets"]:
+    if asset["name"] != "yt-dlp.exe":
         continue
-    download_to(asset['browser_download_url'], work_dir / "root" / "bin", filename="yt-dlp.exe")
+    download_to(
+        asset["browser_download_url"],
+        work_dir / "root" / "bin",
+        filename="yt-dlp.exe",
+    )
 
 # ffmpeg
-download_zip_and_extract_to_bin(work_dir, "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip", "ffmpeg.zip", is_ffmpeg_bin)
+ffmpeg_url = "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip"
+download_zip_and_extract_to_bin(
+    work_dir,
+    ffmpeg_url,
+    "ffmpeg.zip",
+    is_ffmpeg_bin,
+)
 
 # geek uninstaller
-download_zip_and_extract_to_bin(work_dir, "https://geekuninstaller.com/geek.zip", "geek.zip", is_executable)
+download_zip_and_extract_to_bin(
+    work_dir, "https://geekuninstaller.com/geek.zip", "geek.zip", is_executable
+)
 
 # aria2
-github_release = json.loads(webcat("https://api.github.com/repos/aria2/aria2/releases"))[0] # primeira
-for asset in github_release['assets']:
-    if "win-64bit" in asset['name']:
-        download_zip_and_extract_to_bin(work_dir, asset['browser_download_url'], "aria2.zip", is_executable)
+github_release = json.loads(
+    webcat("https://api.github.com/repos/aria2/aria2/releases")
+)[
+    0
+]  # primeira
+for asset in github_release["assets"]:
+    if "win-64bit" in asset["name"]:
+        download_zip_and_extract_to_bin(
+            work_dir,
+            asset["browser_download_url"],
+            "aria2.zip",
+            is_executable,
+        )
 
 
 # Windows Update Blocker
-with tempfile.TemporaryDirectory(prefix='download_wub') as tempdir:
+with tempfile.TemporaryDirectory(prefix="download_wub") as tempdir:
     tempdir = Path(tempdir)
-    downloaded_zip = download_to("https://www.sordum.org/files/downloads.php?st-windows-update-blocker", tempdir, "wub.zip")
-    with zipfile.ZipFile(downloaded_zip, 'r') as z:
+    wub_url = (
+        "https://www.sordum.org/files/downloads.php"
+        "?st-windows-update-blocker"
+    )
+    downloaded_zip = download_to(
+        wub_url,
+        tempdir,
+        "wub.zip",
+    )
+    with zipfile.ZipFile(downloaded_zip, "r") as z:
         z.extractall(tempdir)
-    shutil.move(tempdir / "Wub", work_dir / "root" / "Program Files")
+
+    prog_files = work_dir / "root" / "Program Files"
+    shutil.move(tempdir / "Wub", prog_files)


### PR DESCRIPTION
## What Changed
- Ran `black` and `isort` on `build.py` to fix formatting and sort imports.
- Removed unused imports `urllib.request.Request` and `urllib.request.urlretrieve`.
- Fixed lines that were too long according to `flake8` checks (E501).
- Updated `.jules/janitor.md` with today's insight.

## Why This Helps
- These changes improve the code quality, clarity, and consistency of the Python script.
- Removing unused imports reduces clutter and makes dependencies easier to understand.
- Following formatting guidelines ensures the codebase is easy to read.

## Before/After
- Before: `build.py` contained unused imports and lines exceeding 79/88 characters in length. `isort` and `black` showed the file was improperly formatted.
- After: Unused imports are removed, long strings are wrapped, and the file passes `black --check`, `isort --check`, and `flake8` checks.

## Verification
- Validated formatting with `black build.py --check`.
- Validated imports with `isort build.py --check`.
- Validated lint rules with `flake8 build.py`. All issues were resolved.

## Assumptions
- I assumed standard `black` formatting with line lengths of 88 characters.
- I assumed the journal format should be exactly `- YYYY-MM-DD: [insight]`.

## Alternatives Not Chosen
- Skipping the line-length fixes: This would leave `flake8` unhappy, so I fixed them instead by breaking up strings where necessary.

## How To Pivot
- If you prefer a different line length or formatting style, you can configure `flake8` and `black` with `.flake8` and `pyproject.toml` configuration files in the root repository.

## Next Knobs
- Adjust `black` line length setting.
- Define specific rule ignores for `flake8` in a configuration file.

---
*PR created automatically by Jules for task [10439363537002509654](https://jules.google.com/task/10439363537002509654) started by @lucasew*